### PR TITLE
refactor(dev): optimize kit not needed actually?

### DIFF
--- a/src/api/vite/plugins/core.ts
+++ b/src/api/vite/plugins/core.ts
@@ -60,9 +60,6 @@ export const Core = (config: Configurator.Config): Vite.PluginOption[] => {
           emptyOutDir: true,
           outDir: config.paths.project.buildDir,
         },
-        optimizeDeps: {
-          include: [`@wollybeard/kit`],
-        },
       }
     },
     ...ViteVirtual.IdentifiedLoader.toHooks(


### PR DESCRIPTION
This was previously done because of our alias that was preventing kit
from resolving its internal imports
