### PR TITLE
Fix schema loading issue in reference routes

### DIFF
--- a/src/template/routes/reference.tsx
+++ b/src/template/routes/reference.tsx
@@ -4,7 +4,7 @@ import { Grafaid } from '#lib/grafaid/index'
 import { route, routeIndex } from '#lib/react-router-aid/react-router-aid'
 import { createLoader, useLoaderData } from '#lib/react-router-loader/react-router-loader'
 import { Box } from '@radix-ui/themes'
-import { Outlet, useParams, useRouteLoaderData } from 'react-router'
+import { Outlet, useParams } from 'react-router'
 import { Field } from '../components/Field.js'
 import { MissingSchema } from '../components/MissingSchema.js'
 import { NamedType } from '../components/NamedType.js'
@@ -77,7 +77,7 @@ const RouteReferenceComponent = () => {
 
 // Shared hooks for schema data validation and retrieval
 const useReferenceSchema = () => {
-  const data = useRouteLoaderData('reference') as Awaited<ReturnType<typeof loader>>
+  const data = useLoaderData<typeof loader>('reference')
   if (!data?.schema) {
     throw new Error('Schema not found')
   }

--- a/tests/integration/cases/reference-schema-loading.test.ts
+++ b/tests/integration/cases/reference-schema-loading.test.ts
@@ -5,30 +5,26 @@ import { test } from '../helpers/test.js'
 test('reference pages should load schema content correctly', async ({ page, vite }) => {
   const builder = polen(page, vite).withPokemonSchema()
   
-  await builder
-    .goto('/reference/Pokemon')
-    .then(async p => {
-      // Should not show schema missing error
-      await p.expect.noErrors()
-      
-      // Should show the actual Pokemon type content
-      await expect(page.getByRole('heading', { name: 'Pokemon' })).toBeVisible()
-      await expect(page.getByText('No content to show. There is no schema to work with.')).not.toBeVisible()
-      
-      // Should show some fields from Pokemon type (being more specific to avoid multiple matches)
-      await expect(page.locator('.rt-Text.rt-r-weight-medium').filter({ hasText: 'id' })).toBeVisible()
-      await expect(page.locator('.rt-Text.rt-r-weight-medium').filter({ hasText: 'name' })).toBeVisible()
-    })
+  const p = await builder.goto('/reference/Pokemon')
+  
+  // Should not show schema missing error
+  await p.expect.noErrors()
+  
+  // Should show the actual Pokemon type content
+  await expect(page.getByRole('heading', { name: 'Pokemon' })).toBeVisible()
+  await expect(page.getByText('No content to show. There is no schema to work with.')).not.toBeVisible()
+  
+  // Should show some fields from Pokemon type (being more specific to avoid multiple matches)
+  await expect(page.locator('.rt-Text.rt-r-weight-medium').filter({ hasText: 'id' })).toBeVisible()
+  await expect(page.locator('.rt-Text.rt-r-weight-medium').filter({ hasText: 'name' })).toBeVisible()
 })
 
 test('reference index page should work', async ({ page, vite }) => {
   const builder = polen(page, vite).withPokemonSchema()
   
-  await builder
-    .goto('/reference')
-    .then(async p => {
-      await p.expect.noErrors()
-      await expect(page.getByText('Select a type from the sidebar')).toBeVisible()
-      await expect(page.getByText('No content to show. There is no schema to work with.')).not.toBeVisible()
-    })
+  const p = await builder.goto('/reference')
+  
+  await p.expect.noErrors()
+  await expect(page.getByText('Select a type from the sidebar')).toBeVisible()
+  await expect(page.getByText('No content to show. There is no schema to work with.')).not.toBeVisible()
 })

--- a/tests/integration/cases/reference-schema-loading.test.ts
+++ b/tests/integration/cases/reference-schema-loading.test.ts
@@ -16,12 +16,12 @@ test('reference pages should load schema content correctly', async ({ page, vite
 
   // Should show Fields section
   await expect(page.getByRole('heading', { name: 'Fields' })).toBeVisible()
-  
+
   // Should show field names (using id attributes that are already on field containers)
   // TODO: Consider adding data-testid attributes for more explicit test selectors
   await expect(page.locator('#id')).toBeVisible()
   await expect(page.locator('#name')).toBeVisible()
-  
+
   // Verify field names are displayed with their types
   await expect(page.getByText('id:', { exact: false })).toBeVisible()
   await expect(page.getByText('name:', { exact: false })).toBeVisible()

--- a/tests/integration/cases/reference-schema-loading.test.ts
+++ b/tests/integration/cases/reference-schema-loading.test.ts
@@ -1,0 +1,34 @@
+import { expect } from 'playwright/test'
+import { polen } from '../helpers/polen-builder.js'
+import { test } from '../helpers/test.js'
+
+test('reference pages should load schema content correctly', async ({ page, vite }) => {
+  const builder = polen(page, vite).withPokemonSchema()
+  
+  await builder
+    .goto('/reference/Pokemon')
+    .then(async p => {
+      // Should not show schema missing error
+      await p.expect.noErrors()
+      
+      // Should show the actual Pokemon type content
+      await expect(page.getByRole('heading', { name: 'Pokemon' })).toBeVisible()
+      await expect(page.getByText('No content to show. There is no schema to work with.')).not.toBeVisible()
+      
+      // Should show some fields from Pokemon type (being more specific to avoid multiple matches)
+      await expect(page.locator('.rt-Text.rt-r-weight-medium').filter({ hasText: 'id' })).toBeVisible()
+      await expect(page.locator('.rt-Text.rt-r-weight-medium').filter({ hasText: 'name' })).toBeVisible()
+    })
+})
+
+test('reference index page should work', async ({ page, vite }) => {
+  const builder = polen(page, vite).withPokemonSchema()
+  
+  await builder
+    .goto('/reference')
+    .then(async p => {
+      await p.expect.noErrors()
+      await expect(page.getByText('Select a type from the sidebar')).toBeVisible()
+      await expect(page.getByText('No content to show. There is no schema to work with.')).not.toBeVisible()
+    })
+})

--- a/tests/integration/cases/reference-schema-loading.test.ts
+++ b/tests/integration/cases/reference-schema-loading.test.ts
@@ -4,26 +4,34 @@ import { test } from '../helpers/test.js'
 
 test('reference pages should load schema content correctly', async ({ page, vite }) => {
   const builder = polen(page, vite).withPokemonSchema()
-  
+
   const p = await builder.goto('/reference/Pokemon')
-  
+
   // Should not show schema missing error
   await p.expect.noErrors()
-  
+
   // Should show the actual Pokemon type content
   await expect(page.getByRole('heading', { name: 'Pokemon' })).toBeVisible()
   await expect(page.getByText('No content to show. There is no schema to work with.')).not.toBeVisible()
+
+  // Should show Fields section
+  await expect(page.getByRole('heading', { name: 'Fields' })).toBeVisible()
   
-  // Should show some fields from Pokemon type (being more specific to avoid multiple matches)
-  await expect(page.locator('.rt-Text.rt-r-weight-medium').filter({ hasText: 'id' })).toBeVisible()
-  await expect(page.locator('.rt-Text.rt-r-weight-medium').filter({ hasText: 'name' })).toBeVisible()
+  // Should show field names (using id attributes that are already on field containers)
+  // TODO: Consider adding data-testid attributes for more explicit test selectors
+  await expect(page.locator('#id')).toBeVisible()
+  await expect(page.locator('#name')).toBeVisible()
+  
+  // Verify field names are displayed with their types
+  await expect(page.getByText('id:', { exact: false })).toBeVisible()
+  await expect(page.getByText('name:', { exact: false })).toBeVisible()
 })
 
 test('reference index page should work', async ({ page, vite }) => {
   const builder = polen(page, vite).withPokemonSchema()
-  
+
   const p = await builder.goto('/reference')
-  
+
   await p.expect.noErrors()
   await expect(page.getByText('Select a type from the sidebar')).toBeVisible()
   await expect(page.getByText('No content to show. There is no schema to work with.')).not.toBeVisible()


### PR DESCRIPTION
## Summary
- Fixes critical bug where all reference pages showed "No content to show. There is no schema to work with."
- Child routes couldn't access parent loader data due to improper deserialization
- Uses custom useLoaderData hook with route target for proper superjson deserialization

## Test plan
- ✅ Added comprehensive integration tests for reference page schema loading
- ✅ All existing tests pass
- ✅ Verified schema content renders correctly on Pokemon type page

## Related
This bug was discovered during testing of the version picker duplication fix and affects the production demo site.

🤖 Generated with [Claude Code](https://claude.ai/code)