### PR TITLE
fix: stop killing SSG server right after spawn

### DIFF
--- a/src/api/builder/ssg/generate.ts
+++ b/src/api/builder/ssg/generate.ts
@@ -15,6 +15,7 @@ import {
   PageMessage,
   ServerMessage,
   StartServerMessage,
+  StopServerMessage,
 } from './worker-messages.js'
 import { createPageSpawner, createServerSpawner } from './worker-spawners.js'
 
@@ -130,6 +131,7 @@ export const generate = (config: Config.Config): Effect.Effect<void, Error, File
           ),
           { concurrency: 'unbounded' },
         )
+        yield* Effect.addFinalizer(() => serverPool.broadcast(new StopServerMessage()).pipe(Effect.orDie))
         consola.success(`   All ${optimalWorkers} app instances ready on ports: ${serverPorts.join(', ')}`)
         debug(`All servers started successfully`)
 

--- a/src/api/builder/ssg/server-runner.worker.ts
+++ b/src/api/builder/ssg/server-runner.worker.ts
@@ -113,24 +113,7 @@ const handlers = {
         Effect.catchTag('TimeoutException', () =>
           Effect.die(new Error(`Server on port ${port} failed to start within 30 seconds`))),
       )
-
-      // Add finalizer to ensure cleanup
-      yield* Effect.addFinalizer(() =>
-        Effect.sync(() => {
-          debug(`Finalizer: Stopping server on port ${port}`)
-          if (serverProcess && !serverProcess.killed) {
-            serverProcess.kill('SIGTERM')
-            // Try to kill forcefully after a brief wait
-            setTimeout(() => {
-              if (serverProcess && !serverProcess.killed) {
-                serverProcess.kill('SIGKILL')
-              }
-              serverProcess = null
-            }, 100)
-          }
-        })
-      )
-    }).pipe(Effect.scoped),
+    }),
   StopServer: () =>
     Effect.gen(function*() {
       if (serverProcess) {


### PR DESCRIPTION
This PR fixes the issue of SSG generating nothing, which occurred because the finalizer to stop the server ran immediately after the effect for starting the server was completed, by moving the finalizer to the main generate task.